### PR TITLE
管理者トップページ(注文履歴一覧)：購入日時の日本時間表示とリンク追加、注文ステータスの設定

### DIFF
--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,9 +1,5 @@
 
-<h1>注文履歴一覧</h1>
-
-  <% if admin_signed_in? %>
-    <%= link_to "ログアウト", destroy_admin_session_path, method: :delete %>
-  <% end %>
+<h3>注文履歴一覧</h3>
   
 <table class='table table-hover table-inverse'>
   <thead>
@@ -11,18 +7,18 @@
       <th>購入日時</th>
       <th>購入者</th>
       <th>注文個数</th>
-      <th>注文ステータス(必須機能ではない)</th>
+      <th>注文ステータス</th>
     </tr>
   </thead>
   <tbody>
-    <% @orders.each do |order| %>
+  <% @orders.each do |order| %>
     <tr>
-      <td><%= order.created_at %></td>
+      <td><%= link_to order.created_at.strftime('%Y/%m/%d %H:%M:%S'), admin_accept_order_path(order) %></td>
       <td><%= order.name %></td>
       <td><%= order.order_details.sum(:amount) %></td>
-      <td>注文ステータス</td>
+      <td><%= order.status %></td>
     </tr>
-    <% end %>
+  <% end %>
   </tbody>
 </table>
 <%= paginate @orders %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,8 @@ module NaganoCake
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/*.yml').to_s]


### PR DESCRIPTION
管理者トップページ(注文履歴一覧)に、購入日時の日本時間表示とリンク追加、注文ステータスの設定を行いました。

日本時間表示にするために、config/application.rbに、以下を追記しました。

config.time_zone = 'Tokyo'　　　　　　　　　　←　Rails自体のアプリケーションの時刻の設定
config.active_record.default_timezone = :local　  ←    DBを読み書きする際に、DBに記録されている時間を
                                                                                      どのタイムゾーンで読み込むかの設定